### PR TITLE
iptables: Add ptest

### DIFF
--- a/recipes-debian/iptables/iptables/run-ptest
+++ b/recipes-debian/iptables/iptables/run-ptest
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+#configuration
+TESTDIR="$(dirname $0)/tests"
+RETURNCODE_SEPARATOR="_"
+#XTABLES_NFT_MULTI="${TESTDIR}/../xtables-nft-multi"
+XTABLES_LEGACY_MULTI="${TESTDIR}/../xtables-legacy-multi"
+
+export XTABLES_LIBDIR=${TESTDIR}/../extensions
+
+msg_error() {
+        echo "E: $1 ..." >&2
+        exit 1
+}
+
+msg_warn() {
+        echo "W: $1" >&2
+}
+
+msg_info() {
+        echo "I: $1"
+}
+
+if [ "$(id -u)" != "0" ] ; then
+        msg_error "this requires root!"
+fi
+
+if [ ! -d "$TESTDIR" ] ; then
+        msg_error "missing testdir $TESTDIR"
+fi
+
+if [ "$1" == "-v" ] ; then
+        VERBOSE=y
+        shift
+fi
+
+for arg in "$@"; do
+        if grep ^.*${RETURNCODE_SEPARATOR}[0-9]\\+$ <<< $arg >/dev/null ; then
+                SINGLE+=" $arg"
+                VERBOSE=y
+        else
+                msg_error "unknown parameter '$arg'"
+        fi
+done
+
+find_tests() {
+        if [ ! -z "$SINGLE" ] ; then
+                echo $SINGLE
+                return
+        fi
+        find ${TESTDIR} -executable -regex \
+                .*${RETURNCODE_SEPARATOR}[0-9]+ | sort
+}
+
+ok=0
+failed=0
+
+do_test() {
+	testfile="$1"
+	xtables_multi="$2"
+
+	rc_spec=`echo $(basename ${testfile}) | cut -d _ -f2-`
+
+	#msg_info "[EXECUTING]   $testfile"
+
+	if [ "$VERBOSE" = "y" ]; then
+		XT_MULTI=$xtables_multi unshare -n ${testfile}
+		rc_got=$?
+	else
+		XT_MULTI=$xtables_multi unshare -n ${testfile} > /dev/null 2>&1
+		rc_got=$?
+		#echo -en "\033[1A\033[K" # clean the [EXECUTING] foobar line
+	fi
+
+	if [ "$rc_got" == "$rc_spec" ] ; then
+		#msg_info "[OK]          $testfile"
+		echo "PASS:    $testfile"
+		((ok++))
+	else
+		((failed++))
+		#msg_warn "[FAILED]      $testfile: expected $rc_spec but got $rc_got"
+		echo "FAIL:    $testfile"
+	fi
+}
+
+echo ""
+for testfile in $(find_tests);do
+	do_test "$testfile" "$XTABLES_LEGACY_MULTI"
+done
+msg_info "legacy results: [PASS] $ok [FAIL] $failed [TOTAL] $((ok+failed))"
+
+legacy_ok=$ok
+legacy_fail=$failed
+ok=0
+failed=0
+#for testfile in $(find_tests);do
+#	do_test "$testfile" "$XTABLES_NFT_MULTI"
+#done
+#msg_info "nft results: [PASS] $ok [FAIL] $failed [TOTAL] $((ok+failed))"
+
+ok=$((legacy_ok+ok))
+failed=$((legacy_fail+failed))
+
+#msg_info "combined results: [PASS] $ok [FAIL] $failed [TOTAL] $((ok+failed))"
+
+exit 0

--- a/recipes-debian/iptables/iptables_debian.bb
+++ b/recipes-debian/iptables/iptables_debian.bb
@@ -11,11 +11,12 @@ LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263\
                     file://iptables/iptables.c;beginline=13;endline=25;md5=c5cffd09974558cf27d0f763df2a12dc"
 
-inherit debian-package
+inherit debian-package ptest
 require recipes-debian/sources/iptables.inc
 
 FILESPATH_append = ":${COREBASE}/meta/recipes-extended/iptables/iptables:"
 SRC_URI += " \
+           file://run-ptest \
            file://0001-configure-Add-option-to-enable-disable-libnfnetlink.patch \
            file://0002-configure.ac-only-check-conntrack-when-libnfnetlink-enabled.patch \
 "
@@ -67,3 +68,15 @@ RRECOMMENDS_${PN} = " \
     kernel-module-nf-nat \
     kernel-module-ipt-masquerade \
 "
+
+do_install_ptest () {
+    install -d ${D}${PTEST_PATH}/tests
+
+    cp -r ${B}/extensions ${D}${PTEST_PATH}/
+    find ${D}${PTEST_PATH}/extensions ! -executable -type f -delete
+    ln -s ${sbindir}/xtables-legacy-multi ${D}${PTEST_PATH}/
+
+    cp -r ${S}/iptables/tests/shell ${D}${PTEST_PATH}/tests/
+}
+
+RDEPENDS_${PN}-ptest = "bash diffutils findutils util-linux"

--- a/recipes-debian/iptables/iptables_debian.bb
+++ b/recipes-debian/iptables/iptables_debian.bb
@@ -77,6 +77,7 @@ do_install_ptest () {
     ln -s ${sbindir}/xtables-legacy-multi ${D}${PTEST_PATH}/
 
     cp -r ${S}/iptables/tests/shell ${D}${PTEST_PATH}/tests/
+    find ${D}${PTEST_PATH}/tests/shell/ -type f -exec chmod +x {} \;
 }
 
 RDEPENDS_${PN}-ptest = "bash diffutils findutils util-linux"

--- a/recipes-debian/iptables/iptables_debian.bb
+++ b/recipes-debian/iptables/iptables_debian.bb
@@ -77,7 +77,48 @@ do_install_ptest () {
     ln -s ${sbindir}/xtables-legacy-multi ${D}${PTEST_PATH}/
 
     cp -r ${S}/iptables/tests/shell ${D}${PTEST_PATH}/tests/
-    find ${D}${PTEST_PATH}/tests/shell/ -type f -exec chmod +x {} \;
+    testcases=${D}${PTEST_PATH}/tests/shell/testcases
+    if [ -d $testcases ]; then
+        chmod +x $testcases/*/*_[0-9]
+        cmd='for tbl in nat mangle raw security; do iptables -t $tbl -F; iptables -t $tbl -X; rmmod iptable_$tbl; done'
+        sed  -i -e "N;/do_simple()[ \n]*{/a $cmd" $testcases/*/*_[0-9]
+        old='-j CT --helper \([^ ]\+\)'
+        new='-m helper --helper \1 -j CT'
+        sed -i -e "s/$old/$new/" $testcases/*/dumps/*
+    fi
 }
 
 RDEPENDS_${PN}-ptest = "bash diffutils findutils util-linux"
+RRECOMMENDS_${PN}-ptest = " \
+    kernel-module-iptable-mangle \
+    kernel-module-iptable-raw \
+    kernel-module-iptable-security \
+    kernel-module-ip6-tables \
+    kernel-module-ip6table-raw \
+    kernel-module-ip6table-mangle \
+    kernel-module-ip6table-nat \
+    kernel-module-ip6table-filter \
+    kernel-module-ip6table-security \
+    kernel-module-nfnetlink \
+    kernel-module-nfnetlink-log \
+    kernel-module-xt-nflog \
+    kernel-module-xt-multiport \
+    kernel-module-xt-log \
+    kernel-module-xt-mac \
+    kernel-module-xt-tcpmss \
+    kernel-module-xt-limit \
+    kernel-module-xt-ct \
+    kernel-module-xt-helper \
+    kernel-module-xt-checksum \
+    kernel-module-xt-state \
+    kernel-module-xt-mark \
+    kernel-module-xt-comment \
+    kernel-module-xt-tcpudp \
+    kernel-module-xt-conntrack \
+    kernel-module-nf-log-common \
+    kernel-module-nf-log-ipv4 \
+    kernel-module-nf-conntrack-pptp \
+    kernel-module-nf-conntrack-netbios-ns \
+    kernel-module-ipt-reject \
+    kernel-module-ip6t-reject \
+"


### PR DESCRIPTION
# Purpose of pull request

This PR adds ptest of iptables package based on the following test code:

- package: iptables-1.8.2
- test code directory path: iptables-1.8.2/iptables/tests

couldn't find any reference recipes that add ptest.

# Test

## How to test

1.Enable ptest and install iptables package
```
$ . setup-emlinux
$ cat <<EOF >> conf/local.conf
MACHINE = "qemuarm64"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " iptables"
EOF
```

2.add kernel configs
```
CONFIG_IP_NF_RAW=m
CONFIG_IP_NF_SECURITY=m
CONFIG_IP6_NF_RAW=m
CONFIG_IP6_NF_SECURITY=m
CONFIG_NETFILTER_XT_MARK=m
CONFIG_NETFILTER_XT_CONNMARK=m
CONFIG_NETFILTER_XT_TARGET_CONNMARK=m
CONFIG_NETFILTER_XT_TARGET_MARK=m
CONFIG_NETFILTER_XT_TARGET_TCPMSS=m
CONFIG_NETFILTER_XT_TARGET_CT=m
CONFIG_NETFILTER_XT_TARGET_NFLOG=m
CONFIG_NETFILTER_XT_MATCH_CONNMARK=m
CONFIG_NETFILTER_XT_MATCH_MARK=m
CONFIG_NETFILTER_XT_MATCH_COMMENT=m
CONFIG_NETFILTER_XT_MATCH_STATE=m
CONFIG_NETFILTER_XT_MATCH_LIMIT=m
CONFIG_NETFILTER_XT_MATCH_HELPER=m
CONFIG_NETFILTER_XT_MATCH_MAC=m
CONFIG_NETFILTER_XT_MATCH_TCPMSS=m
CONFIG_NETFILTER_XT_MATCH_MULTIPORT=m
CONFIG_NF_CONNTRACK_PPTP=m
CONFIG_NF_CONNTRACK_NETBIOS_NS=m
```

3.Build core-image-minimal
```
$ bitbake core-image-minimal
```

4.Run qemu and execute ptest of iptables
```
$ runqemu nographic
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner iptables
```

Also, I confirmed that SDK build succeeds with `bitbake core-image-minimal-sdk -c populate_sdk`.

## Test result

```
root@qemuarm64:~# ptest-runner iptables
START: ptest-runner
2023-12-25T02:43
BEGIN: /usr/lib/iptables/ptest

PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/arptables/0001-arptables-save-restore_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/arptables/0002-arptables-restore-defaults_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/chain/0001duplicate_1
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/chain/0002newchain_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/chain/0003rename_1
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ebtables/0001-ebtables-basic_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ebtables/0002-ebtables-save-restore_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ebtables/0003-ebtables-restore-defaults_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/firewalld-restore/0001-firewalld_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/firewalld-restore/0002-firewalld-restart_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ip6tables/0002-verbose-output_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ip6tables/0003-list-rules_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ip6tables/0004-return-codes_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ipt-restore/0001load-specific-table_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ipt-restore/0002-parameters_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ipt-save/0001load-dumps_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ipt-save/0002load-fedora27-firewalld_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ipt-save/0003save-restore_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ipt-save/0005iptables_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/iptables/0001-chain-refs_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/iptables/0002-verbose-output_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/iptables/0003-list-rules_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/iptables/0004-return-codes_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/nft-only/0001compat_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/nft-only/0002invflags_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/nft-only/0003delete-with-comment_0
I: legacy results: [PASS] 26 [FAIL] 0 [TOTAL] 26
DURATION: 11
END: /usr/lib/iptables/ptest
2023-12-25T02:43
STOP: ptest-runner
root@qemuarm64:~# ptest-runner iptables
START: ptest-runner
2023-12-25T02:44
BEGIN: /usr/lib/iptables/ptest

PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/arptables/0001-arptables-save-restore_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/arptables/0002-arptables-restore-defaults_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/chain/0001duplicate_1
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/chain/0002newchain_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/chain/0003rename_1
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ebtables/0001-ebtables-basic_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ebtables/0002-ebtables-save-restore_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ebtables/0003-ebtables-restore-defaults_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/firewalld-restore/0001-firewalld_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/firewalld-restore/0002-firewalld-restart_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ip6tables/0002-verbose-output_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ip6tables/0003-list-rules_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ip6tables/0004-return-codes_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ipt-restore/0001load-specific-table_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ipt-restore/0002-parameters_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ipt-save/0001load-dumps_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ipt-save/0002load-fedora27-firewalld_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ipt-save/0003save-restore_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ipt-save/0005iptables_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/iptables/0001-chain-refs_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/iptables/0002-verbose-output_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/iptables/0003-list-rules_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/iptables/0004-return-codes_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/nft-only/0001compat_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/nft-only/0002invflags_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/nft-only/0003delete-with-comment_0
I: legacy results: [PASS] 26 [FAIL] 0 [TOTAL] 26
DURATION: 12
END: /usr/lib/iptables/ptest
2023-12-25T02:44
STOP: ptest-runner
root@qemuarm64:~# ptest-runner iptables
START: ptest-runner
2023-12-25T02:45
BEGIN: /usr/lib/iptables/ptest

PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/arptables/0001-arptables-save-restore_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/arptables/0002-arptables-restore-defaults_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/chain/0001duplicate_1
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/chain/0002newchain_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/chain/0003rename_1
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ebtables/0001-ebtables-basic_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ebtables/0002-ebtables-save-restore_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ebtables/0003-ebtables-restore-defaults_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/firewalld-restore/0001-firewalld_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/firewalld-restore/0002-firewalld-restart_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ip6tables/0002-verbose-output_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ip6tables/0003-list-rules_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ip6tables/0004-return-codes_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ipt-restore/0001load-specific-table_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ipt-restore/0002-parameters_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ipt-save/0001load-dumps_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ipt-save/0002load-fedora27-firewalld_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ipt-save/0003save-restore_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/ipt-save/0005iptables_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/iptables/0001-chain-refs_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/iptables/0002-verbose-output_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/iptables/0003-list-rules_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/iptables/0004-return-codes_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/nft-only/0001compat_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/nft-only/0002invflags_0
PASS:    /usr/lib/iptables/ptest/tests/shell/testcases/nft-only/0003delete-with-comment_0
I: legacy results: [PASS] 26 [FAIL] 0 [TOTAL] 26
DURATION: 11
END: /usr/lib/iptables/ptest
2023-12-25T02:45
STOP: ptest-runner
```
