### PR TITLE
glib-2.0: Fix ptest

### DIFF
--- a/recipes-debian/glib-2.0/glib-2.0/run-ptest
+++ b/recipes-debian/glib-2.0/glib-2.0/run-ptest
@@ -1,0 +1,6 @@
+#! /bin/sh
+
+set -eux
+useradd glib2-test
+su glib2-test -c "CHARSET=UTF-8 gnome-desktop-testing-runner glib"
+userdel -r glib2-test

--- a/recipes-debian/glib-2.0/glib-2.0_debian.bbappend
+++ b/recipes-debian/glib-2.0/glib-2.0_debian.bbappend
@@ -2,3 +2,9 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/glib-2.0:"
 SRC_URI += " \
     file://0001-Do-not-write-bindir-into-pkg-config-files.patch \
 "
+RDEPENDS_${PN}-ptest_append_libc-glibc += "\
+            locale-base-ja-jp \
+            locale-base-fr-fr \
+            glibc-localedata-fr-fr \
+            glibc-binary-localedata-fr-fr \
+           "


### PR DESCRIPTION
<h1>Purpose of pull request</h1>

This PR fixes an error in glib-2.0 ptest caused by missing locales.

Error below:
```
GLib:ERROR:../glib-2.58.3/glib/tests/gdatetime.c:1477:test_non_utf8_printf: assertion failed (__p == ("10\346\234\210")): ("Oct" == "10\346\234\210")
Bail out! GLib:ERROR:../glib-2.58.3/glib/tests/gdatetime.c:1477:test_non_utf8_printf: assertion failed (__p == ("10\346\234\210")): ("Oct" == "10\346\234\210")
FAIL: glib/gdatetime.test (Child process killed by signal 6)
``` 

<h1>Test</h1>

<h2>How to test</h2>

1.Enable ptest and install glib-2.0 package
```
$ . setup-emlinux
$ cat <<EOF >> conf/local.conf
MACHINE = "qemuarm64"
DISTRO_FEATURES_append = " ptest"
CORE_IMAGE_EXTRA_INSTALL += "ptest-runner glib-2.0-ptest glibc-ptest iptables-ptest libnl-ptest coreutils"
EOF
```
 
2.Build core-image-minimal
```
$ bitbake core-image-minimal
```

3.Run qemu and execute ptest of glib-2.0
```
$ runqemu nographic
...(snip)...
# ptest-runner glib-2.0
```

<h2>Test result</h2>

```
root@qemuarm64:~# ptest-runner glib-2.0
START: ptest-runner
2023-12-12T08:26
BEGIN: /usr/lib/glib-2.0/ptest
+ useradd glib2-test
+ su glib2-test -c 'CHARSET=UTF-8 gnome-desktop-testing-runner glib'
[   20.970036] random: gnome-desktop-t: uninitialized urandom read (16 bytes read)
Running test: glib/gdbus-test-codegen.test
[   21.022723] random: gdbus-test-code: uninitialized urandom read (16 bytes read)
# random seed: R02S355d2ea992e044f35bd480757d3b38d6
# GLib-DEBUG: posix_spawn avoided (automatic reaping requested) (fd close requested)
[   21.055724] random: dbus-daemon: uninitialized urandom read (12 bytes read)
1..6
# Start of gdbus tests
# Start of codegen tests
ok 1 /gdbus/codegen/annotations
ok 2 /gdbus/codegen/interface_stability
...(snip)...
# Start of to-iso8601 tests
ok 8 /timeval/to-iso8601/overflow
# End of to-iso8601 tests
# End of timeval tests
PASS: glib/timer.test
SUMMARY: total=246; passed=245; skipped=0; failed=1; user=554.7s; system=203.6s; maxrss=250200
FAIL: glib/gdatetime.test (Child process killed by signal 6)

ERROR: Exit status is 512
DURATION: 1047
END: /usr/lib/glib-2.0/ptest
2023-12-12T08:44
STOP: ptest-runner
```
[test-result.txt](https://github.com/ML-HirotakaFurukawa/meta-debian-extended/files/13645825/test-result.txt)


The error in question has been avoided, but the following error still occurs.
```
ok 35 /GDateTime/modifiers
# Bug Reference: http://bugzilla.gnome.org/749206
**
GLib:ERROR:../glib-2.58.3/glib/tests/gdatetime.c:1683:test_month_names: assertion failed (p_casefold == (o_casefold)): ("sep" == "sept.")
Bail out! GLib:ERROR:../glib-2.58.3/glib/tests/gdatetime.c:1683:test_month_names: assertion failed (p_casefold == (o_casefold)): ("sep" == "sept.")
FAIL: glib/gdatetime.test (Child process killed by signal 6)
Running test: glib/gdbus-test-codegen-old.test
# random seed: R02S22b5e45a5421c90e645aed0d0eaf5eb9
# GLib-DEBUG: posix_spawn avoided (automatic reaping requested) (fd close requested)
1..6
# Start of gdbus tests
# Start of codegen tests
ok 1 /gdbus/codegen/annotations
```

The test code that causes the error is below.
```
  setlocale (LC_ALL, "fr_FR.utf-8");
  if (strstr (setlocale (LC_ALL, NULL), "fr_FR") != NULL)
    {
      TEST_PRINTF_DATE (2018,  7,  1,  "%B", "juillet");
      TEST_PRINTF_DATE (2018,  8,  1, "%OB", "aout");
      TEST_PRINTF_DATE (2018,  9,  1,  "%b", "sept.");    <= This
      TEST_PRINTF_DATE (2018, 10,  1, "%Ob", "oct.");
      TEST_PRINTF_DATE (2018, 11,  1,  "%h", "nov.");
      TEST_PRINTF_DATE (2018, 12,  1, "%Oh", "de c.");
    }
```

This occurs even when the French locale is added, so it has been determined that the ptest is not an issue.
The date command works correctly as shown below.
```
root@qemuarm64:~# export LC_ALL=fr_FR.utf-8
root@qemuarm64:~# date -d 2018/09/01 +%b
sept.
```

