### PR TITLE
cracklib: Add ptest

### DIFF
--- a/recipes-debian/cracklib/cracklib/0003-Fix-a-missing-header-inclusion.patch
+++ b/recipes-debian/cracklib/cracklib/0003-Fix-a-missing-header-inclusion.patch
@@ -1,0 +1,41 @@
+From ca82afa20436beaef99dff9d36930274c9bd4d41 Mon Sep 17 00:00:00 2001
+From: Kazuho Sasaki <sasaki.kazuho@meta.co.jp>
+Date: Mon, 4 Dec 2023 11:58:30 +0900
+Subject: [PATCH] Fix a missing header inclusion
+
+This is a follow-up patch of
+"libcrack2-error-safer-check-variant.patch", which causes build failure
+of tests.
+
+FIX:
+| In file included from ../../cracklib-2.9.6/util/teststr.c:9:
+| ../../cracklib-2.9.6/lib/crack.h:32:41: error: unknown type name 'size_t'
+|                                          size_t errmsg_len);
+|                                          ^~~~~~
+| ../../cracklib-2.9.6/lib/crack.h:32:41: note: 'size_t' is defined in header '<stddef.h>'; did you forget to '#include <stddef.h>'?
+| ../../cracklib-2.9.6/lib/crack.h:1:1:
+| +#include <stddef.h>
+|  #ifndef CRACKLIB_H
+| ../../cracklib-2.9.6/lib/crack.h:32:41:
+|                                          size_t errmsg_len);
+|                                          ^~~~~~
+| make[2]: *** [Makefile:562: teststr.o] Error 1
+
+Signed-off-by: Kazuho Sasaki <sasaki.kazuho@meta.co.jp>
+---
+ lib/crack.h | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/lib/crack.h b/lib/crack.h
+index 2e83f5a..bf095ea 100644
+--- a/lib/crack.h
++++ b/lib/crack.h
+@@ -1,6 +1,8 @@
+ #ifndef CRACKLIB_H
+ #define CRACKLIB_H
+ 
++#include <stddef.h>
++
+ #ifdef __cplusplus
+ extern "C" {
+ #endif

--- a/recipes-debian/cracklib/cracklib/expected-data
+++ b/recipes-debian/cracklib/cracklib/expected-data
@@ -1,0 +1,10 @@
+antzer: it is based on a dictionary word
+G@ndalf: OK
+neulinger: it is based on a dictionary word
+lantzer: OK
+Pa$$w0rd: it is based on a dictionary word
+PaS$W0rd: it is based on a dictionary word
+Pas$w0rd: it is based on a dictionary word
+Pas$W0rd: it is based on a dictionary word
+Pa$sw0rd: it is based on a dictionary word
+Pa$sW0rd: it is based on a dictionary word

--- a/recipes-debian/cracklib/cracklib/run-ptest
+++ b/recipes-debian/cracklib/cracklib/run-ptest
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+CRACKLIBDIR=@libdir@/cracklib
+LOG="$CRACKLIBDIR/ptest/cracklib_ptest_$(date +%Y%m%d-%H%M%S).log"
+
+make test | while read -r line; do
+    if echo "$line" | grep -q '^.*: '; then
+        if grep -q "^$line\$" expected-data; then
+            echo "PASS: $line"
+        else
+            echo "FAIL: $line"
+        fi
+    else
+        echo "$line" # not a test output, just pass through
+    fi
+done | tee -a "$LOG"
+
+PASSED=$(grep -c '^PASS: ' "$LOG")
+FAILED=$(grep -c '^FAIL: ' "$LOG")
+ALL=$((PASSED + FAILED))
+
+(   echo "=== Test Summary ==="
+    echo "TOTAL: $ALL"
+    echo "PASSED: $PASSED"
+    echo "FAILED: $FAILED"
+) | tee -a "$LOG"

--- a/recipes-debian/cracklib/cracklib_debian.bb
+++ b/recipes-debian/cracklib/cracklib_debian.bb
@@ -17,12 +17,37 @@ EXTRA_OECONF = "--without-python --libdir=${base_libdir}"
 
 FILESPATH_append = ":${COREBASE}/meta/recipes-extended/cracklib/cracklib:"
 SRC_URI += "file://0001-packlib.c-support-dictionary-byte-order-dependent.patch \
-			file://0002-craklib-fix-testnum-and-teststr-failed.patch"
+            file://0002-craklib-fix-testnum-and-teststr-failed.patch \
+            file://0003-Fix-a-missing-header-inclusion.patch \
+            file://run-ptest \
+            file://expected-data \
+           "
 
-inherit autotools gettext
+inherit autotools gettext ptest
+
+do_compile_ptest() {
+    oe_runmake check
+}
 
 do_install_append_class-target() {
 	create-cracklib-dict -o ${D}${datadir}/cracklib/pw_dict ${D}${datadir}/cracklib/cracklib-small
 }
+
+do_install_ptest() {
+    install -m 644 ${B}/Makefile ${D}${PTEST_PATH}
+    sed -e 's/^test:.*/test:/' \
+        -e '/^Makefile: /s/^.*$/Makefile:/g' \
+        -i ${D}${PTEST_PATH}/Makefile
+
+    install -dm 755 ${D}${PTEST_PATH}/util/
+    install -m 755 ${B}/util/.libs/cracklib-check ${D}${PTEST_PATH}/util/
+    install -m 644 ${S}/test-data ${D}${PTEST_PATH}
+    install -m 644 ${WORKDIR}/expected-data ${D}${PTEST_PATH}
+
+    # handle multilib
+    sed -i s:@libdir@:${libdir}:g ${D}${PTEST_PATH}/run-ptest
+}
+
+RDEPENDS_${PN}-ptest += "make"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
# Purpose of pull request

This PR adds ptest of cracklib.

This ptest executes `make test` to test the strength of some passwords and check the results.

# Note

`0003-Fix-a-missing-header-inclusion.patch` is a follow-up patch of `libcrack2-error-safer-check-variant.patch` (Debian patch).
If ptest is enabled, `libcrack2-error-safer-check-variant.patch` causes the following build failure.
`0003-Fix-a-missing-header-inclusion.patch` is necessary to fix this issue.

```
| In file included from ../../cracklib-2.9.6/util/teststr.c:9:
| ../../cracklib-2.9.6/lib/crack.h:32:41: error: unknown type name 'size_t'
|                                          size_t errmsg_len);
|                                          ^~~~~~
| ../../cracklib-2.9.6/lib/crack.h:32:41: note: 'size_t' is defined in header '<stddef.h>'; did you forget to '#include <stddef.h>'?
| ../../cracklib-2.9.6/lib/crack.h:1:1:
| +#include <stddef.h>
|  #ifndef CRACKLIB_H
| ../../cracklib-2.9.6/lib/crack.h:32:41:
|                                          size_t errmsg_len);
|                                          ^~~~~~
```

Also, cracklib doesn't have any expected data for `make test`, so `expected-data` is newly added to compare it with the actual result.

# Test
## How to test

1. Enable ptest and install cracklib package

```
$ . setup-emlinux
$ cat << EOS >> conf/local.conf
MACHINE = "qemuarm64"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " cracklib"
EOS
```

2. Build core-image-minimal image

```
$ bitbake core-image-minimal
```

3. Run qemu and execute ptest of cracklib

```
$ runqemu nographic
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner cracklib
```

Also, I confirmed that SDK build succeeds with `bitbake core-image-minimal-sdk -c populate_sdk`.

## Test result

```
root@qemuarm64:~# ptest-runner -l
Available ptests:
acl     /usr/lib/acl/ptest/run-ptest
busybox /usr/lib/busybox/ptest/run-ptest
cracklib        /usr/lib/cracklib/ptest/run-ptest
util-linux      /usr/lib/util-linux/ptest/run-ptest
zlib    /usr/lib/zlib/ptest/run-ptest
root@qemuarm64:~# ptest-runner cracklib
START: ptest-runner
2023-12-22T00:07
BEGIN: /usr/lib/cracklib/ptest

=======================================================
If you get an error when running make test about a
missing pw_dict.pwd file, that indicates that the word
list dictionary file has not been built. You need to
at least run make install and make dict to install
the dictionay. See the README file for more details.
=======================================================

util/cracklib-check < test-data
(data fread failed): Success
(data fread failed): Invalid argument
(data fread failed): Success
(data fread failed): Success
(data fread failed): Success
(data fread failed): Success
(data fread failed): Success
PASS: antzer: it is based on a dictionary word
PASS: G@ndalf: OK
PASS: neulinger: it is based on a dictionary word
PASS: lantzer: OK
PASS: Pa$$w0rd: it is based on a dictionary word
PASS: PaS$W0rd: it is based on a dictionary word
PASS: Pas$w0rd: it is based on a dictionary word
PASS: Pas$W0rd: it is based on a dictionary word
PASS: Pa$sw0rd: it is based on a dictionary word
PASS: Pa$sW0rd: it is based on a dictionary word
=== Test Summary ===
TOTAL: 10
PASSED: 10
FAILED: 0
DURATION: 2
END: /usr/lib/cracklib/ptest
2023-12-22T00:08
STOP: ptest-runner
```

[ptest-cracklib.log](https://github.com/ML-HirotakaFurukawa/meta-debian-extended/files/13747017/ptest-cracklib.log)

## Test summary

* TOTAL: 10
  * PASS: 10
  * FAIL: 0

I executed this ptest 3 times and obtained the same results